### PR TITLE
test: md-parser / block-transforms 統合テスト追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,4 +101,4 @@ Markdown → (md-parser) → AST → (block-transforms) → createBlock() → se
 
 - コメント・ドキュメントは日本語
 - Conventional Commits（日本語メッセージ可）
-- ブランチ: `feature/YYYYMM/sakashita44/<issue_num>-<内容>`
+- ブランチ: `<prefix>/YYYYMM/sakashita44/<issue_num>-<内容>`

--- a/test/block-transforms/index.test.ts
+++ b/test/block-transforms/index.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { parseMd } from '../../lib/md-parser.js';
+import { transformTokens } from '../../lib/block-transforms/index.js';
+import { mockToken } from '../helpers/mock-token.js';
+
+const noPlugins = new Set<string>();
+
+describe('transformTokens', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('空のトークン配列: 空のブロック配列を返す', () => {
+        const blocks = transformTokens([], noPlugins);
+        expect(blocks).toHaveLength(0);
+    });
+
+    it('単一の段落を変換', () => {
+        const { tokens } = parseMd('Hello world');
+        const blocks = transformTokens(tokens, noPlugins);
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0].name).toBe('core/paragraph');
+    });
+
+    it('複数ブロックの統合変換（段落 + 見出し + コードブロック）', () => {
+        const { tokens } = parseMd(`段落テキスト
+
+## 見出し
+
+\`\`\`js
+const x = 1;
+\`\`\``);
+        const blocks = transformTokens(tokens, noPlugins);
+        expect(blocks).toHaveLength(3);
+        expect(blocks[0].name).toBe('core/paragraph');
+        expect(blocks[1].name).toBe('core/heading');
+        expect(blocks[2].name).toBe('core/code');
+    });
+
+    it('未対応トークンに対して console.warn を出力', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const unknownToken = mockToken({ type: 'unknown_custom_type' });
+        transformTokens([unknownToken], noPlugins);
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('未対応トークン'),
+        );
+    });
+
+    it('CONSUMED_TOKEN_TYPES のトークンは console.warn を出力しない', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const consumedTokens = [
+            mockToken({ type: 'paragraph_close' }),
+            mockToken({ type: 'inline' }),
+        ];
+        transformTokens(consumedTokens, noPlugins);
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('境界ケース: paragraph_open が末尾（後続トークンなし）', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const tokens = [mockToken({ type: 'paragraph_open' })];
+        const blocks = transformTokens(tokens, noPlugins);
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('paragraph_open'),
+        );
+        expect(blocks).toHaveLength(0);
+    });
+
+    it('境界ケース: heading_open が末尾（後続トークンなし）', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const tokens = [mockToken({ type: 'heading_open', tag: 'h2' })];
+        const blocks = transformTokens(tokens, noPlugins);
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('heading_open'),
+        );
+        expect(blocks).toHaveLength(0);
+    });
+});

--- a/test/block-transforms/index.test.ts
+++ b/test/block-transforms/index.test.ts
@@ -42,7 +42,9 @@ const x = 1;
         const unknownToken = mockToken({ type: 'unknown_custom_type' });
         transformTokens([unknownToken], noPlugins);
         expect(warnSpy).toHaveBeenCalledWith(
-            expect.stringContaining('未対応トークン'),
+            expect.stringMatching(
+                /^\[warn\] 未対応トークン: unknown_custom_type（スキップ）$/,
+            ),
         );
     });
 
@@ -61,7 +63,9 @@ const x = 1;
         const tokens = [mockToken({ type: 'paragraph_open' })];
         const blocks = transformTokens(tokens, noPlugins);
         expect(warnSpy).toHaveBeenCalledWith(
-            expect.stringContaining('paragraph_open'),
+            expect.stringMatching(
+                /^\[warn\] paragraph_open の後にトークンがありません$/,
+            ),
         );
         expect(blocks).toHaveLength(0);
     });
@@ -71,7 +75,9 @@ const x = 1;
         const tokens = [mockToken({ type: 'heading_open', tag: 'h2' })];
         const blocks = transformTokens(tokens, noPlugins);
         expect(warnSpy).toHaveBeenCalledWith(
-            expect.stringContaining('heading_open'),
+            expect.stringMatching(
+                /^\[warn\] heading_open の後にトークンがありません$/,
+            ),
         );
         expect(blocks).toHaveLength(0);
     });

--- a/test/block-transforms/index.test.ts
+++ b/test/block-transforms/index.test.ts
@@ -81,4 +81,23 @@ const x = 1;
         );
         expect(blocks).toHaveLength(0);
     });
+
+    it('plugins に katex を含む場合、インライン数式を paragraph ブロック（[katex]ショートコード）に変換', () => {
+        const { tokens } = parseMd('$E = mc^2$');
+        const blocks = transformTokens(tokens, new Set(['katex']));
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0].name).toBe('core/paragraph');
+        expect(String(blocks[0].attributes.content)).toBe(
+            '[katex]E = mc^2[/katex]',
+        );
+    });
+
+    it('段落が単独 URL の場合、embed ブロックに変換', () => {
+        const { tokens } = parseMd(
+            'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        );
+        const blocks = transformTokens(tokens, new Set());
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0].name).toBe('core/embed');
+    });
 });

--- a/test/md-parser.test.ts
+++ b/test/md-parser.test.ts
@@ -54,6 +54,14 @@ categories: []
             expect(tokens).toHaveLength(0);
         });
 
+        it('必須フィールド不足: エラーにならず部分的に返す', () => {
+            const md = `---\ntitle: テスト\n---\n本文`;
+            const { frontmatter } = parseMd(md);
+            expect(frontmatter.title).toBe('テスト');
+            expect(frontmatter.slug).toBeUndefined();
+            expect(frontmatter.categories).toBeUndefined();
+        });
+
         it('不正 YAML frontmatter: エラーをスロー', () => {
             // js-yaml は未クローズのフロー記法を不正として例外を投げる
             const md = `---

--- a/test/md-parser.test.ts
+++ b/test/md-parser.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { parseMd } from '../lib/md-parser.js';
+
+describe('parseMd', () => {
+    describe('frontmatter パース', () => {
+        it('正常系: 必須フィールドを含む frontmatter を抽出', () => {
+            const md = `---
+title: テスト記事
+slug: test-article
+categories:
+  - tech
+---
+本文テキストです。`;
+            const { frontmatter, tokens } = parseMd(md);
+            expect(frontmatter.title).toBe('テスト記事');
+            expect(frontmatter.slug).toBe('test-article');
+            expect(frontmatter.categories).toEqual(['tech']);
+            expect(tokens.length).toBeGreaterThan(0);
+        });
+
+        it('正常系: オプションフィールドも抽出', () => {
+            const md = `---
+title: テスト
+slug: test
+categories: []
+tags:
+  - tag1
+excerpt: 概要テキスト
+date: '2026-01-01'
+featured_image: cover.jpg
+---`;
+            const { frontmatter } = parseMd(md);
+            expect(frontmatter.tags).toEqual(['tag1']);
+            expect(frontmatter.excerpt).toBe('概要テキスト');
+            expect(frontmatter.date).toBe('2026-01-01');
+            expect(frontmatter.featured_image).toBe('cover.jpg');
+        });
+
+        it('frontmatter なし: 空オブジェクトを返す', () => {
+            const md = '本文のみです。';
+            const { frontmatter, tokens } = parseMd(md);
+            expect(frontmatter).toEqual({});
+            expect(tokens.length).toBeGreaterThan(0);
+        });
+
+        it('frontmatter のみ（本文なし）: トークン配列が空', () => {
+            const md = `---
+title: テスト
+slug: test
+categories: []
+---`;
+            const { frontmatter, tokens } = parseMd(md);
+            expect(frontmatter.title).toBe('テスト');
+            expect(tokens).toHaveLength(0);
+        });
+
+        it('不正 YAML frontmatter: エラーをスロー', () => {
+            // js-yaml は未クローズのフロー記法を不正として例外を投げる
+            const md = `---
+title: [unclosed bracket
+---`;
+            expect(() => parseMd(md)).toThrow();
+        });
+
+        it('空文字列: 空の frontmatter と空のトークン配列を返す', () => {
+            const { frontmatter, tokens } = parseMd('');
+            expect(frontmatter).toEqual({});
+            expect(tokens).toHaveLength(0);
+        });
+    });
+
+    describe('トークン生成', () => {
+        it('見出しを含む本文で対応するトークンを生成', () => {
+            const { tokens } = parseMd('# 見出し');
+            const types = tokens.map((t) => t.type);
+            expect(types).toContain('heading_open');
+            expect(types).toContain('inline');
+            expect(types).toContain('heading_close');
+        });
+
+        it('コードブロックを含む本文で fence トークンを生成', () => {
+            const { tokens } = parseMd('```js\nconst x = 1;\n```');
+            const types = tokens.map((t) => t.type);
+            expect(types).toContain('fence');
+        });
+
+        it('段落を含む本文で paragraph トークンを生成', () => {
+            const { tokens } = parseMd('段落テキスト');
+            const types = tokens.map((t) => t.type);
+            expect(types).toContain('paragraph_open');
+            expect(types).toContain('paragraph_close');
+        });
+    });
+});


### PR DESCRIPTION
## 概要

Issue #10 で指摘されたテスト不足を解消する。

- `test/md-parser.test.ts` を新規追加
- `test/block-transforms/index.test.ts` を新規追加

## 追加したテスト

### `test/md-parser.test.ts`

| テストケース | 検証内容 |
|---|---|
| 正常系: 必須フィールドを含む frontmatter | title / slug / categories が正しく抽出される |
| 正常系: オプションフィールドも抽出 | tags / excerpt / date / featured_image を抽出 |
| frontmatter なし | 空オブジェクトを返し、本文からトークンを生成 |
| frontmatter のみ（本文なし） | トークン配列が空 |
| 不正 YAML frontmatter | エラーをスロー |
| 空文字列 | 空の frontmatter と空のトークン配列 |
| 見出しトークン生成 | heading_open / inline / heading_close を含む |
| fence トークン生成 | コードブロックが fence として生成される |
| 段落トークン生成 | paragraph_open / paragraph_close を含む |

### `test/block-transforms/index.test.ts`

| テストケース | 検証内容 |
|---|---|
| 空のトークン配列 | 空のブロック配列を返す |
| 単一の段落 | core/paragraph が1つ生成される |
| 複数ブロック統合変換 | paragraph + heading + code の順で3ブロック生成 |
| 未対応トークン | console.warn に「未対応トークン」が含まれる |
| CONSUMED_TOKEN_TYPES のスキップ | paragraph_close / inline で warn が出力されない |
| 境界ケース: paragraph_open が末尾 | warn が出力され、ブロックが生成されない |
| 境界ケース: heading_open が末尾 | warn が出力され、ブロックが生成されない |

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)