### PR TITLE
feat: WP REST API v2 互換性チェックを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ### 1) 前提
 
 - Node.js v20+
-- WordPress 6.x+（REST API が有効であること）
+- WordPress 6.x+（REST API v2 が有効であること。4.7+ で標準搭載）
 
 #### WordPress 側の設定
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -82,6 +82,7 @@ export interface MdpubCache {
 
 /** WP REST API クライアントのインターフェース */
 export interface WpClient {
+    checkApiCompatibility(): Promise<void>;
     findMediaBySlug(slug: string): Promise<WpMedia | null>;
     findPostBySlug(slug: string): Promise<WpPost | null>;
     findCategoryBySlug(slug: string): Promise<WpTerm | null>;

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -87,6 +87,7 @@ try {
 
     const articleSlug: string = frontmatter.slug;
     const wp = createWpClient(config);
+    await wp.checkApiCompatibility();
 
     const plugins = loadPlugins(projectRoot);
 

--- a/scripts/upload-media.ts
+++ b/scripts/upload-media.ts
@@ -25,7 +25,7 @@ import {
     resolveArticleDirPath,
 } from '../lib/cli-config.js';
 import { resolveProjectRoot } from '../lib/project-root.js';
-import type { WpClientConfig } from '../lib/types.js';
+import type { WpClientConfig, WpClient } from '../lib/types.js';
 
 const projectRoot = resolveProjectRoot(import.meta.url);
 
@@ -126,19 +126,13 @@ if (images.length === 0) {
 
 // --- WP クライアント初期化 ---
 let config: WpClientConfig;
+let wp: WpClient;
 try {
     config = getWpConfig();
-} catch (e) {
-    console.error((e as Error).message);
-    process.exit(1);
-}
-
-const wp = createWpClient(config);
-
-try {
+    wp = createWpClient(config);
     await wp.checkApiCompatibility();
 } catch (e) {
-    console.error(`❌ ${(e as Error).message}`);
+    console.error((e as Error).message);
     process.exit(1);
 }
 

--- a/scripts/upload-media.ts
+++ b/scripts/upload-media.ts
@@ -135,6 +135,13 @@ try {
 
 const wp = createWpClient(config);
 
+try {
+    await wp.checkApiCompatibility();
+} catch (e) {
+    console.error(`❌ ${(e as Error).message}`);
+    process.exit(1);
+}
+
 // --- アップロード実行 ---
 console.log(`\n📁 記事: ${articleSlug}`);
 console.log(`📷 画像: ${images.length} 件`);


### PR DESCRIPTION
## 概要

`publish` / `upload-media` 実行時に WordPress が REST API v2 に対応しているかを事前チェックする。v2 非対応の場合、個々の API 呼び出しで意味不明なエラーが出る問題を、明確なエラーメッセージで即時終了することで解消する。

## 変更内容

- `WpClient` インターフェースに `checkApiCompatibility(): Promise<void>` を追加
- `createWpClient` に `checkApiCompatibility` メソッドを実装
  - 認証なしで `GET /wp-json/` を呼び `namespaces` に `wp/v2` が含まれるか検証
  - `/wp-json/` が 404 の場合は `?rest_route=/` にフォールバック（既存パターンと統一）
  - 非対応時は `WP REST API v2 が有効でない可能性があります（WordPress 4.7+ が必要です）` でエラー throw
- `scripts/publish.ts` / `scripts/upload-media.ts` で `createWpClient` 直後にチェックを呼び出し
- `test/wp-client.test.ts` にテスト 5 件追加
- `README.md` の前提セクションに REST API v2 必須を補足

Closes #24